### PR TITLE
Minor changes

### DIFF
--- a/ILTransform/ILRewriter.cs
+++ b/ILTransform/ILRewriter.cs
@@ -417,7 +417,8 @@ namespace ILTransform
                 rewritten = true;
             }
 
-            bool usingXUnit = (_testProject.LastUsingLine >= 0 && lines[_testProject.LastUsingLine].Contains("Xunit"));
+            Regex usingXunitRegex = new Regex(@"^\s*using\s+Xunit\s*(?:\\,*)?;");
+            bool usingXUnit = (_testProject.LastUsingLine >= 0 && lines.Take(_testProject.LastUsingLine).Any(l => usingXunitRegex.IsMatch(l)));
             if (_settings.AddILFactAttributes && !isILTest && !usingXUnit)
             {
                 int rewriteLine = _testProject.LastUsingLine;
@@ -426,11 +427,7 @@ namespace ILTransform
                     rewriteLine = _testProject.LastHeaderCommentLine;
                 }
                 rewriteLine++;
-                Regex usingXunitRegex = new Regex(@"^\s*using\s+Xunit\s*(?:\\,*)?;");
-                if (!lines.Any(l => usingXunitRegex.IsMatch(l)))
-                {
-                    lines.Insert(rewriteLine++, "using Xunit;");
-                }
+                lines.Insert(rewriteLine++, "using Xunit;");
                 rewritten = true;
             }
 

--- a/ILTransform/ILRewriter.cs
+++ b/ILTransform/ILRewriter.cs
@@ -426,7 +426,8 @@ namespace ILTransform
                     rewriteLine = _testProject.LastHeaderCommentLine;
                 }
                 rewriteLine++;
-                if (!lines.Any(l => l.Contains("using Xunit")))
+                Regex usingXunitRegex = new Regex(@"^\s*using\s+Xunit\s*(?:\\,*)?;");
+                if (!lines.Any(l => usingXunitRegex.IsMatch(l)))
                 {
                     lines.Insert(rewriteLine++, "using Xunit;");
                 }

--- a/ILTransform/ILRewriter.cs
+++ b/ILTransform/ILRewriter.cs
@@ -426,7 +426,10 @@ namespace ILTransform
                     rewriteLine = _testProject.LastHeaderCommentLine;
                 }
                 rewriteLine++;
-                lines.Insert(rewriteLine++, "using Xunit;");
+                if (!lines.Any(l => l.Contains("using Xunit")))
+                {
+                    lines.Insert(rewriteLine++, "using Xunit;");
+                }
                 rewritten = true;
             }
 

--- a/ILTransform/TestProject.cs
+++ b/ILTransform/TestProject.cs
@@ -419,16 +419,6 @@ namespace ILTransform
             return false;
         }
 
-        public string ReplaceOrUpdateStringWithVars(string input)
-        {
-            // TestLibraryProjectPath is a global variable that any test can include so remove prev and post path
-            if (input.Contains("$(TestLibraryProjectPath)"))
-            {
-                return "$(TestLibraryProjectPath)";
-            }
-            return input;
-        }
-
         public bool HasSameContentAs(TestProject project2)
         {
             if (CompileFiles.Length == 0 || project2.CompileFiles.Length == 0)
@@ -445,8 +435,8 @@ namespace ILTransform
             }
             for (int refIndex = 0; refIndex < ProjectReferences.Length; refIndex++)
             {
-                string ref1 = ReplaceOrUpdateStringWithVars(ProjectReferences[refIndex]);
-                string ref2 = ReplaceOrUpdateStringWithVars(project2.ProjectReferences[refIndex]);
+                string ref1 = ProjectReferences[refIndex];
+                string ref2 = project2.ProjectReferences[refIndex];
                 try
                 {
                     if (ref1 != ref2

--- a/ILTransform/TestProject.cs
+++ b/ILTransform/TestProject.cs
@@ -1075,26 +1075,29 @@ namespace ILTransform
                 if (testProject.IsILProject)
                 {
                     TestProject.GetKeyNameRootNameAndSuffix(renamedFile, out _, out string rootName, out _);
-                    string sourceRootName = Path.GetFileNameWithoutExtension(testProject.CompileFiles.Single());
-
-                    if ((rootName != sourceRootName)
-                        && string.Equals(rootName, sourceRootName, StringComparison.OrdinalIgnoreCase))
+                    if (testProject.CompileFiles.Length == 1)
                     {
-                        // HACK: If we have "foo.ilproj" and "Foo.il", we'll have trouble doing the
-                        // case-sensitive rename of "Foo.il" to "foo.il", so we'll use "foo_.ilproj"
-                        // instead and then the rename to foo_.il will work.
+                        string sourceRootName = Path.GetFileNameWithoutExtension(testProject.CompileFiles.Single());
 
-                        // And if we're going to this trouble anyway, see if the name has a case
-                        // mismatch with the directory name.
-
-                        string innerDirectoryName = Path.GetFileName(dir);
-                        if ((renamedFile != innerDirectoryName)
-                            && string.Equals(renamedFile, innerDirectoryName, StringComparison.OrdinalIgnoreCase))
+                        if ((rootName != sourceRootName)
+                            && string.Equals(rootName, sourceRootName, StringComparison.OrdinalIgnoreCase))
                         {
-                            renamedFile = innerDirectoryName;
-                        }
+                            // HACK: If we have "foo.ilproj" and "Foo.il", we'll have trouble doing the
+                            // case-sensitive rename of "Foo.il" to "foo.il", so we'll use "foo_.ilproj"
+                            // instead and then the rename to foo_.il will work.
 
-                        renamedFile += "_";
+                            // And if we're going to this trouble anyway, see if the name has a case
+                            // mismatch with the directory name.
+
+                            string innerDirectoryName = Path.GetFileName(dir);
+                            if ((renamedFile != innerDirectoryName)
+                                && string.Equals(renamedFile, innerDirectoryName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                renamedFile = innerDirectoryName;
+                            }
+
+                            renamedFile += "_";
+                        }
                     }
                 }
 

--- a/ILTransform/TestProject.cs
+++ b/ILTransform/TestProject.cs
@@ -419,6 +419,16 @@ namespace ILTransform
             return false;
         }
 
+        public string ReplaceOrUpdateStringWithVars(string input)
+        {
+            // TestLibraryProjectPath is a global variable that any test can include so remove prev and post path
+            if (input.Contains("$(TestLibraryProjectPath)"))
+            {
+                return "$(TestLibraryProjectPath)";
+            }
+            return input;
+        }
+
         public bool HasSameContentAs(TestProject project2)
         {
             if (CompileFiles.Length == 0 || project2.CompileFiles.Length == 0)
@@ -435,11 +445,14 @@ namespace ILTransform
             }
             for (int refIndex = 0; refIndex < ProjectReferences.Length; refIndex++)
             {
-                string ref1 = ProjectReferences[refIndex];
-                string ref2 = project2.ProjectReferences[refIndex];
+                string ref1 = ReplaceOrUpdateStringWithVars(ProjectReferences[refIndex]);
+                string ref2 = ReplaceOrUpdateStringWithVars(project2.ProjectReferences[refIndex]);
                 try
                 {
-                    if (ref1 != ref2 && File.ReadAllText(ref1) != File.ReadAllText(ref2))
+                    if (ref1 != ref2
+                        && !ref1.Contains("$(TestLibraryProjectPath)")
+                        && !ref2.Contains("$(TestLibraryProjectPath)")
+                        && File.ReadAllText(ref1) != File.ReadAllText(ref2))
                     {
                         return false;
                     }


### PR DESCRIPTION
If an il proj includes more than one file it just breaks but it could just continue doing nothing there.

Considering TestLibraryProjectPath var on content comparison to get a cleaner useful stdout on each run.