### PR TITLE
Fix -a flag and extend token lists

### DIFF
--- a/ILTransform/ILRewriter.cs
+++ b/ILTransform/ILRewriter.cs
@@ -556,7 +556,7 @@ namespace ILTransform
                                 }
                             }
                             int identEnd = charIndex;
-                            string sourceName = Path.GetFileNameWithoutExtension(source);
+                            TestProject.GetKeyNameRootNameAndSuffix(_testProject.TestProjectAlias, out _, out string sourceName, out _);
                             if (sourceName != assemblyName)
                             {
                                 string end = line.Substring(identEnd);

--- a/ILTransform/ILRewriter.cs
+++ b/ILTransform/ILRewriter.cs
@@ -734,7 +734,7 @@ namespace ILTransform
             && ((tokens[index + 1] == "::") || (tokens[index + 1] == "/")) // type::field or type::nestedtype
             && (kinds[index + 2] == TokenKind.Identifier || kinds[index + 2] == TokenKind.SingleQuoted);
 
-        private static string[] TypeDefTokens = { "public", "auto", "ansi" };
+        private static string[] TypeDefTokens = { "public", "abstract", "auto", "ansi", "sealed", "beforefieldinit" };
         private static bool IsTypeNameDef(List<string> tokens, List<TokenKind> kinds, int index)
         {
             for (; index >= 2; index -= 2)

--- a/ILTransform/ILRewriter.cs
+++ b/ILTransform/ILRewriter.cs
@@ -556,7 +556,7 @@ namespace ILTransform
                                 }
                             }
                             int identEnd = charIndex;
-                            TestProject.GetKeyNameRootNameAndSuffix(_testProject.TestProjectAlias, out _, out string sourceName, out _);
+                            TestProject.GetKeyNameRootNameAndSuffix(_testProject.RelativePath, out _, out string sourceName, out _);
                             if (sourceName != assemblyName)
                             {
                                 string end = line.Substring(identEnd);

--- a/ILTransform/TestProject.cs
+++ b/ILTransform/TestProject.cs
@@ -239,7 +239,7 @@ namespace ILTransform
 
         public static List<string> SpecialTokens() => new List<string> {
             "add", "and", "br", "brtrue", "brfalse", "ble", "blt", "beq", "bge", "bgt", "call", "ceq", "cgt", "ckfinite", "clt", "cpblk", "div",
-            "dup", "filter", "finally", "initblk", "jmp", "ldobj", "ldtoken", "mul", "neg", "nested", "nop", "rem", "ret", "sub", "xor", "callvirt",
+            "dup", "filter", "finally", "initblk", "jmp", "ldobj", "ldtoken", "ldftn", "mul", "neg", "nested", "nop", "rem", "ret", "sub", "xor", "callvirt",
             "castclass", "cpobj", "initobj", "isinst", "switch", "rethrow"
         };
 


### PR DESCRIPTION
- Set -a to match assembly names and ilproj filenames without extensions. Seems reasonable to fail if TestProjectAlias is null as it would be unmasking a problem getting the ilproj filename without extensions.
- Extends special token and typedef token list based on what is needed for tests under JIT/jit64.